### PR TITLE
Fix release feedback issue

### DIFF
--- a/nbgrader/exchange/release_feedback.py
+++ b/nbgrader/exchange/release_feedback.py
@@ -38,6 +38,10 @@ class ExchangeReleaseFeedback(Exchange):
 
         html_files = glob.glob(os.path.join(self.src_path, "*.html"))
         for html_file in html_files:
+            if 'hashcode' in html_file:
+                self.log.debug("Skpping hashcode info")
+                continue
+
             regexp = re.escape(os.path.sep).join([
                 self.coursedir.format_path(
                     self.coursedir.feedback_directory,


### PR DESCRIPTION
* release_assignment.py takes all `.html` file and hash it to create id for the feedback, but it also takes `.ipynb` file, which does not exist for the `.._hashcode.html`.