### PR TITLE
Feature/restrict submit

### DIFF
--- a/nbgrader/exchange/collect.py
+++ b/nbgrader/exchange/collect.py
@@ -12,7 +12,6 @@ from ..utils import check_mode, parse_utc
 
 import pandas as pd
 import csv
-import re
 
 # pwd is for matching unix names with student ide, so we shouldn't import it on
 # windows machines

--- a/nbgrader/exchange/collect.py
+++ b/nbgrader/exchange/collect.py
@@ -12,6 +12,7 @@ from ..utils import check_mode, parse_utc
 
 import pandas as pd
 import csv
+import re
 
 # pwd is for matching unix names with student ide, so we shouldn't import it on
 # windows machines
@@ -71,7 +72,6 @@ class ExchangeCollect(Exchange):
                 dest_path = os.path.join(self.inbound_path, os.path.splitext(zipped_sub)[0])
                 dest_path = os.path.join(self.http_submit_path, dest_path)
                 shutil.unpack_archive(sub_path, dest_path, "zip")
-            # FIXME: split inbound
         elif self.enable_k8s_submit:
             self.inbound_path = os.path.join(self.course_path, self.k8s_inbound) 
         else:
@@ -82,11 +82,40 @@ class ExchangeCollect(Exchange):
         
         if not check_mode(self.inbound_path, read=True, execute=True):
             self.fail("You don't have read permissions for the directory: {}".format(self.inbound_path))
-        student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
-        pattern = os.path.join(self.inbound_path, '{}+{}+*'.format(student_id, self.coursedir.assignment_id))
-        records = [self._path_to_record(f) for f in glob.glob(pattern)]
-        usergroups = groupby(records, lambda item: item['username'])
-        self.src_records = [self._sort_by_timestamp(v)[0] for v in usergroups.values()]
+
+        #look into student id dir if submission dir is restricted
+        if self.restrict_submit:
+            self.log.info("Collecting from restricted submit dirs")
+            #skip dir that contains nbgrader submit patter, take dir with username only e.g. mwasil2s
+            submit_dirs = [username for username in os.listdir(self.inbound_path) if "+" not in username and 
+                           os.path.isdir(os.path.join(self.inbound_path, username))]
+            self.log.info("Submission dirs {}".format(submit_dirs))
+
+            self.src_records = []
+            for username in submit_dirs:
+                submit_path = os.path.join(self.inbound_path, username)
+                self.log.info("Assignment id: {}".format(self.coursedir.assignment_id))
+                pattern = os.path.join(submit_path, '{}+{}+*'.format(username, self.coursedir.assignment_id))
+                records = [self._path_to_record(f) for f in glob.glob(pattern)]
+                self.log.info("[{}] Total submission: ".format(username, len(records)))
+                #update file path
+                for i,record in enumerate(records):
+                    filename = os.path.join(submit_path,record['filename'])
+                    records[i]['filename'] = filename
+                
+                usergroups = groupby(records, lambda item: item['username'])
+                user_record = self._sort_by_timestamp(records)
+                self.log.info("[{}]: {}".format(username, user_record))
+                if len(user_record) > 0:
+                    self.src_records.append(user_record[0])
+
+        else:
+            student_id = self.coursedir.student_id if self.coursedir.student_id else '*'
+            pattern = os.path.join(self.inbound_path, '{}+{}+*'.format(student_id, self.coursedir.assignment_id))
+        
+            records = [self._path_to_record(f) for f in glob.glob(pattern)]
+            usergroups = groupby(records, lambda item: item['username'])
+            self.src_records = [self._sort_by_timestamp(v)[0] for v in usergroups.values()]
 
     def init_dest(self):
         pass

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -120,6 +120,14 @@ class Exchange(LoggingConfigurable):
         help="Exchange outbound directory"
     ).tag(config=True)
 
+    restrict_submit = Bool(
+        False,
+        help=dedent(
+            "Whether to create submit directory for each JupyterHub user"
+            "This only works with k8s and needs JupyterHub"
+        )
+    ).tag(config=True)
+
     coursedir = Instance(CourseDirectory, allow_none=True)
     authenticator = Instance(Authenticator, allow_none=True)
 

--- a/nbgrader/exchange/submit.py
+++ b/nbgrader/exchange/submit.py
@@ -36,7 +36,7 @@ class ExchangeSubmit(Exchange):
             "Whether to add a random string on the end of the submission."
         )
     ).tag(config=True)
-
+    
     def init_src(self):
         if self.path_includes_course:
             root = os.path.join(self.coursedir.course_id, self.coursedir.assignment_id)
@@ -54,8 +54,13 @@ class ExchangeSubmit(Exchange):
             self.fail("No course id specified. Re-run with --course flag.")
         if not self.authenticator.has_access(self.coursedir.student_id, self.coursedir.course_id):
             self.fail("You do not have access to this course.")
+       
+        #each student has their own submit dir (only works with k8s)
+        if self.restrict_submit:
+            self.inbound_path = os.path.join(self.root, self.coursedir.course_id, 'inbound', os.getenv('JUPYTERHUB_USER'))
+        else:
+            self.inbound_path = os.path.join(self.root, self.coursedir.course_id, 'inbound')
 
-        self.inbound_path = os.path.join(self.root, self.coursedir.course_id, 'inbound')
         if not os.path.isdir(self.inbound_path):
             self.fail("Inbound directory doesn't exist: {}".format(self.inbound_path))
         if not check_mode(self.inbound_path, write=True, execute=True):


### PR DESCRIPTION
* Add reconfigurable submit dir for each jhub username
  * This directory will be first created during spawn
* By default it's False, to configure `c.Exchange.restrict_submit = True `
* Unlike normal nbgrader submit dir which is writable by all, this submit dir is only writable by the jhub username
* Require jupyterhub user